### PR TITLE
Update megasync-2.9.6.ebuild

### DIFF
--- a/net-misc/megasync/megasync-2.9.6.ebuild
+++ b/net-misc/megasync/megasync-2.9.6.ebuild
@@ -22,7 +22,7 @@ RDEPEND="dev-libs/crypto++
 	sys-libs/zlib
 	dev-db/sqlite:3
 	net-dns/c-ares
-	net-misc/curl[ssl]
+	net-misc/curl[ssl,curl_ssl_openssl]
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
 	dev-qt/qtdbus:4"


### PR DESCRIPTION
Megasync required curl with openssl support.
If curl built with some else ssl support, megasync client close immediately.
$ megasync --debug
17:52:19 (warn): QT Warning: QSystemTrayIcon::setVisible: No Icon set
17:52:19 (fatal): cURL built without OpenSSL support. Aborting. (net.cpp:39)
